### PR TITLE
Add parameter to store IAM access and secret key in SecretsManager

### DIFF
--- a/veeam-backup-and-replication/capacity-tier-s3-setup-immutable/cf-veeam-s3-immutability.yaml
+++ b/veeam-backup-and-replication/capacity-tier-s3-setup-immutable/cf-veeam-s3-immutability.yaml
@@ -18,6 +18,16 @@ Parameters:
     MaxLength: 64
     AllowedPattern: '[a-zA-Z][a-zA-Z0-9\-]*'
     ConstraintDescription: Refer to AWS IAM documentation for name requirements and character limits. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+  OutputCredentialLocation:
+    Default: "CloudFormation"
+    Description: "Location to output the IAM user credentials. Options: CloudFormation, SecretsManager. Additional costs associated with SecretsManager"
+    Type: String
+    AllowedValues:
+      - CloudFormation
+      - SecretsManager
+
+Conditions:
+  UseSecretsManager: !Equals [!Ref OutputCredentialLocation, "SecretsManager"]
 
 Resources:
   VeeamS3Bucket:
@@ -76,15 +86,17 @@ Resources:
 
   # Consider storing the IAM secret key in AWS Secrets Manager for secure storage and access.
   # This option is not enabled by default because secrets stored in AWS Secrets Manager incur a monthly cost. Refer to AWS documentation for details.
-  #
-  # IAMSecretAccessKey:
-  #   Type: AWS::SecretsManager::Secret
-  #   UpdateReplacePolicy: Delete
-  #   DeletionPolicy: Delete
-  #   Properties:
-  #     Name: VeeamS3AccessKey
-  #     Description: Access key used by Veeam to access S3.
-  #     SecretString: !Sub '{"AccessKey":"${IAMAccessKey}","SecretAccessKey":"${IAMAccessKey.SecretAccessKey}"}'
+  # To enable it set the OutputCredentialLocation parameter to "SecretsManager".
+
+  IAMSecretAccessKey:
+    Type: AWS::SecretsManager::Secret
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Condition: UseSecretsManager
+    Properties:
+      Name: VeeamS3AccessKey
+      Description: Access key used by Veeam to access S3.
+      SecretString: !Sub '{"AccessKey":"${IAMAccessKey}","SecretAccessKey":"${IAMAccessKey.SecretAccessKey}"}'
 
 Outputs:
   Region:
@@ -96,12 +108,17 @@ Outputs:
     Description: Veeam S3 IAM user
 
   AccessKey:
-    Value: !Ref IAMAccessKey
+    Value: !If
+      - UseSecretsManager
+      - !Sub "SecretKey stored in AWS Secrets Manager ${IAMSecretAccessKey}"
+      - !Ref IAMAccessKey
     Description: Access key ID of new user
 
-  # Remove the "SecretKey" output if you opt to use AWS Secrets Manager to store the secret key (more secure).
   SecretKey:
-    Value: !GetAtt IAMAccessKey.SecretAccessKey
+    Value: !If
+      - UseSecretsManager
+      - "SecretKey stored in AWS Secrets Manager"
+      - !GetAtt IAMAccessKey.SecretAccessKey
     Description: Secret access key of new user
 
   VeeamS3Bucket:

--- a/veeam-backup-and-replication/capacity-tier-s3-setup-standard/cf-veeam-s3-standard.yaml
+++ b/veeam-backup-and-replication/capacity-tier-s3-setup-standard/cf-veeam-s3-standard.yaml
@@ -18,6 +18,16 @@ Parameters:
     MaxLength: 64
     AllowedPattern: '[a-zA-Z][a-zA-Z0-9\-]*'
     ConstraintDescription: Refer to AWS IAM documentation for name requirements and character limits. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+  OutputCredentialLocation:
+    Default: "CloudFormation"
+    Description: "Location to output the IAM user credentials. Options: CloudFormation, SecretsManager. Additional costs associated with SecretsManager"
+    Type: String
+    AllowedValues:
+      - CloudFormation
+      - SecretsManager
+
+Conditions:
+  UseSecretsManager: !Equals [!Ref OutputCredentialLocation, "SecretsManager"]
 
 Resources:
   VeeamS3Bucket:
@@ -68,15 +78,17 @@ Resources:
 
   # Consider storing the IAM secret key in AWS Secrets Manager for secure storage and access.
   # This option is not enabled by default because secrets stored in AWS Secrets Manager incur a monthly cost. Refer to AWS documentation for details.
-  #
-  # IAMSecretAccessKey:
-  #   Type: AWS::SecretsManager::Secret
-  #   UpdateReplacePolicy: Delete
-  #   DeletionPolicy: Delete
-  #   Properties:
-  #     Name: VeeamS3AccessKey
-  #     Description: Access key used by Veeam to access S3.
-  #     SecretString: !Sub '{"AccessKey":"${IAMAccessKey}","SecretAccessKey":"${IAMAccessKey.SecretAccessKey}"}'
+  # To enable it set the OutputCredentialLocation parameter to "SecretsManager".
+
+  IAMSecretAccessKey:
+    Type: AWS::SecretsManager::Secret
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Condition: UseSecretsManager
+    Properties:
+      Name: VeeamS3AccessKey
+      Description: Access key used by Veeam to access S3.
+      SecretString: !Sub '{"AccessKey":"${IAMAccessKey}","SecretAccessKey":"${IAMAccessKey.SecretAccessKey}"}'
 
 Outputs:
   Region:
@@ -88,12 +100,17 @@ Outputs:
     Description: Veeam S3 IAM user
 
   AccessKey:
-    Value: !Ref IAMAccessKey
+    Value: !If
+      - UseSecretsManager
+      - !Sub "SecretKey stored in AWS Secrets Manager ${IAMSecretAccessKey}"
+      - !Ref IAMAccessKey
     Description: Access key ID of new user
 
-  # Remove the "SecretKey" output if you opt to use AWS Secrets Manager to store the secret key (more secure).
   SecretKey:
-    Value: !GetAtt IAMAccessKey.SecretAccessKey
+    Value: !If
+      - UseSecretsManager
+      - "SecretKey stored in AWS Secrets Manager"
+      - !GetAtt IAMAccessKey.SecretAccessKey
     Description: Secret access key of new user
 
   VeeamS3Bucket:


### PR DESCRIPTION
# Pull Request

By contributing, you agree that your contributions will be licensed under the projects original open source license.

* [x] Agree

## Description

This change adds a parameter to the Veeam Backup and Recovery CloudFormation template to optionally add output to Secrets Manager of AWS IAM credentials. This avoids needing to modify the template by commenting out sections.

If Secrets Manager is chosen the CloudFormation outputs refer users to check Secrets Manager for the values. CloudFormation output is left as the default value.


### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

I've deployed multiple variations of this change into my own AWS accounts to test and have validated the configuration works and creates the requested resources.

### Checklist (check all applicable):

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in _hard to understand_ areas
* [X] I have made corresponding changes to the documentation
* [X] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

I've also validated that my changes pass [cfn-lint](https://github.com/aws-cloudformation/cfn-lint).
